### PR TITLE
UInt64

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
I was curious to see the effect of calculating two elements at once (by casting the `Span` to a bigger struct, `UInt64`). Turns out it's only slightly better than `Branchless`. Is there any way you can think of to improve on it?

I got the idea from this [answer](https://stackoverflow.com/a/43191293) of mine for comparing byte arrays (pre-`Span`, uses `Unsafe.As`, which amounts to the same thing, except for the length adjustment).

PS - you don't have to merge this :) Just wanted the debate.

|           Method |        Mean |      Error |     StdDev |      Median |     Op/s | Scaled | ScaledSD | Allocated |
|----------------- |------------:|-----------:|-----------:|------------:|---------:|-------:|---------:|----------:|
| SortablePerValue | 10,536.5 us |  36.316 us |  30.325 us | 10,530.7 us |    94.91 |   1.00 |     0.00 |       0 B |
|  ToRadixPerValue | 10,996.9 us | 105.282 us |  93.330 us | 11,026.4 us |    90.93 |   1.04 |     0.01 |       0 B |
|     ToRadixBlock | 10,736.1 us | 155.262 us | 145.232 us | 10,811.0 us |    93.14 |   1.02 |     0.01 |       0 B |
|      ToRadixSpan |  8,348.5 us | 163.664 us | 244.965 us |  8,224.1 us |   119.78 |   0.79 |     0.02 |       0 B |
|       Branchless |  2,548.8 us |  55.315 us |  93.929 us |  2,498.7 us |   392.34 |   0.24 |     0.01 |       0 B |
|           UInt64 |  2,379.2 us |   4.827 us |   4.515 us |  2,379.3 us |   420.31 |   0.23 |     0.00 |       0 B |
|       Vectorized |    754.2 us |   2.111 us |   1.975 us |    753.4 us | 1,325.99 |   0.07 |     0.00 |      24 B |
|    BranchlessXor |  2,366.9 us |   8.351 us |   7.811 us |  2,365.4 us |   422.49 |   0.22 |     0.00 |       0 B |
|    VectorizedXor |    757.0 us |   7.613 us |   7.121 us |    753.4 us | 1,320.95 |   0.07 |     0.00 |      24 B |
